### PR TITLE
Show how to distribute the super simple simulation

### DIFF
--- a/oceananigans-dynamical-core/super_simple_simulation.jl
+++ b/oceananigans-dynamical-core/super_simple_simulation.jl
@@ -7,16 +7,17 @@ Reactant.Ops.DEBUG_MODE[] = true
 ENV["JULIA_DEBUG"] = "Reactant_jll"
 @show Reactant_jll.cuDriverGetVersion(dlopen("libcuda.so"))
 
-arch = GPU() # CPU() to run on CPU
+# arch = CPU()
+# arch = Distributed(GPU(), partition=Partition(2, 2)) # distributed on 4 GPUs
+arch = GPU()
 Nx, Ny, Nz = (360, 120, 100) # number of cells
 
 grid = LatitudeLongitudeGrid(arch, size=(Nx, Ny, Nz), halo=(7, 7, 7),
                              longitude=(0, 360), latitude=(-60, 60), z=(-1000, 0))
 
 # One of the implest configurations we might consider:
-model = HydrostaticFreeSurfaceModel(; grid, momentum_advection=WENO())
-
-@assert model.free_surface isa SplitExplicitFreeSurface
+free_surface = SplitExplicitFreeSurface(substeps=30)
+model = HydrostaticFreeSurfaceModel(; grid, free_surface, momentum_advection=WENO())
 
 uᵢ(x, y, z) = randn()
 set!(model, u=uᵢ, v=uᵢ)


### PR DESCRIPTION
To distribute a simulation:

1. Change the architecture from `GPU()` (or CPU) to `Distributed(GPU())` or `Distributed(GPU(), partition=partition)` to manually configure the way the simulation is partitioned across GPUs.

2. Right now we also need to change one aspect of the simulation (this may be eliminated in the future): we need to fix the substeps of the free surface solver with `free_surface = SplitExplicitFreeSurface(substeps=N)`. `N=30` may work for the current configuration (the number of substeps depends on both the resolution and the time-step of the simulation).