### PR TITLE
Manually add free surface in data_free script

### DIFF
--- a/ocean-climate-simulation/data_free_ocean_climate_simulation.jl
+++ b/ocean-climate-simulation/data_free_ocean_climate_simulation.jl
@@ -73,7 +73,8 @@ zb = z_faces[1]
 h = -zb + 100
 gaussian_islands(λ, φ) = zb + h * (mtn₁(λ, φ) + mtn₂(λ, φ))
 grid = @gbprofile "ImmersedBoundaryGrid" ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(gaussian_islands))
-ocean = @gbprofile "ocean_simulation" ocean_simulation(grid)
+free_surface = SplitExplicitFreeSurface(grid, fixed_Δt=Δt, cfl=0.7)
+ocean = @gbprofile "ocean_simulation" ocean_simulation(grid; free_surface)
 
 # Simple initial condition for producing pretty pictures
 φ₀ = 40


### PR DESCRIPTION
The same pattern may be used in any script with `ocean_simulation`.

Note that ClimaOcean#main tries to determine a good default: https://github.com/CliMA/ClimaOcean.jl/blob/5f6d1705b17929f818bd7ed63e745288be3f8b03/src/OceanSimulations.jl#L124

However older versions of `ClimaOcean` may not.