### PR TITLE
Update Oceananigans and ClimaOcean compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,5 @@ Reactant_jll = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"
 
 [compat]
 Reactant = "0.2.35"
-ClimaOcean = "0.4.4"
+ClimaOcean = "0.4.5"
+Oceananigans = "0.95.20"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Reactant_jll = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"
 
 [compat]
-Reactant = "0.2.35"
 ClimaOcean = "0.4.5"
 Oceananigans = "0.95.20"
+Reactant = "0.2.37"

--- a/Project.toml
+++ b/Project.toml
@@ -2,12 +2,12 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CFTime = "179af706-886a-5703-950a-314cd64e0468"
 ClimaOcean = "0376089a-ecfe-4b0e-a64f-9c555d74d754"
+ClimaSeaIce = "6ba0ff68-24e6-4315-936c-2e99227c95a4"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 OrthogonalSphericalShellGrids = "c2be9673-fb75-4747-82dc-aa2bb9f4aed0"
 Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Reactant_jll = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"
 
 [compat]
-ClimaOcean = "0.4.3"
-Oceananigans = "0.95.17"
 Reactant = "0.2.35"
+ClimaOcean = "0.4.4"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,6 @@ Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Reactant_jll = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"
 
 [compat]
-ClimaOcean = "0.4.2"
-Oceananigans = "=0.95.12"
+ClimaOcean = "0.4.3"
+Oceananigans = "0.95.17"
 Reactant = "0.2.35"

--- a/ocean-climate-simulation/data_free_ocean_climate_simulation.jl
+++ b/ocean-climate-simulation/data_free_ocean_climate_simulation.jl
@@ -116,7 +116,8 @@ function gaussian_islands_tripolar_grid(arch::Architectures.AbstractArchitecture
     h = -zb + 100
     gaussian_islands(λ, φ) = zb + h * (mtn₁(λ, φ) + mtn₂(λ, φ))
 
-    return @gbprofile "ImmersedBoundaryGrid" ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(gaussian_islands))
+    return @gbprofile "ImmersedBoundaryGrid" ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(gaussian_islands);
+                                                                  active_cells_map=false)
 end
 
 function data_free_ocean_climate_simulation_init(arch::Architectures.AbstractArchitecture=Architectures.ReactantState())
@@ -154,7 +155,7 @@ function data_free_ocean_climate_simulation_init(arch::Architectures.AbstractArc
     parent(atmosphere.downwelling_radiation.shortwave) .= parent(Qs)
 
     # Atmospheric model
-    radiation  = Radiation(arch)
+    radiation = Radiation(arch)
 
     # Coupled model and simulation
     solver_stop_criteria = FixedIterations(5) # note: more iterations = more accurate


### PR DESCRIPTION
Updates to use Oceananigans PRs:

Bugfix in OceananigansReactantExt (the original reason for the Oceananigans version pin), plus features to make the grid "constant" in the eyes of Reactant:
* https://github.com/CliMA/Oceananigans.jl/pull/4151

We need to test that the consequences of this are as expected here in MLIR.

We also added the capacity to precompute data structures for interpolating from one grid to another:
* https://github.com/CliMA/Oceananigans.jl/pull/4146 

This allows us to avoid the "on-the-fly" interpolation that resulted in a complicated `interpolate_atmosphere_state` kernel. Avoiding on-the-fly interpolation is implemented here:
* https://github.com/CliMA/ClimaOcean.jl/pull/353