### PR TITLE
Avoid conversion of (potentially large) MLIR modules to strings

### DIFF
--- a/ocean-climate-simulation/ocean_climate_simulation_mlir.jl
+++ b/ocean-climate-simulation/ocean_climate_simulation_mlir.jl
@@ -11,12 +11,12 @@ unopt = @code_hlo optimize=false raise=true run!(simulation)
 
 # Unoptimized HLO
 open("unopt_ocean_climate_simulation.mlir", "w") do io
-    write(io, string(unopt))
+    show(io, unopt)
 end
 
 # Optimized HLO
 opt = @code_hlo optimize=:before_jit raise=true run!(simulation)
 
 open("opt_ocean_climate_simulation.mlir", "w") do io
-    write(io, string(opt))
+    show(io, opt)
 end


### PR DESCRIPTION
Taking out of #28.