### PR TITLE
Dump raw profile data instead of extra text file with C

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,6 +89,8 @@ jobs:
         if: ${{ always() }}
         with:
           name: 'ocean-simulation-profile-${{ matrix.version }}-${{ matrix.os }}'
-          path: '**/profile_*.txt'
+          path: |
+            **/profile_*.txt
+            **/profile_*.dat
           retention-days: 90
           overwrite: false

--- a/src/data_free_ocean_climate_simulation.jl
+++ b/src/data_free_ocean_climate_simulation.jl
@@ -67,12 +67,7 @@ macro gbprofile(name::String, expr::Expr)
                 println(s, "# at ", $(string(__source__)))
                 $(Profile.print)(IOContext(s, :displaysize => (48, 1000)))
             end
-            open(string("profile_with_c_", $(esc(name)), ".txt"), "w") do s
-                println(s, "# Showing profile of")
-                println(s, "#     ", $(string(expr)))
-                println(s, "# at ", $(string(__source__)))
-                $(Profile.print)(IOContext(s, :displaysize => (48, 1000)); C=true)
-            end
+            write(string("profile_", $(esc(name)), ".dat"), $(Profile).fetch())
             $(Profile.clear)()
             out
         else


### PR DESCRIPTION
This should allow us to use other visualisers later. For getting back the data with the C calls:

```
Profile.print(collect(reinterpret(UInt64, read("/path/to/profile.dat"))))
```