### PR TITLE
Serialize `Profile.retrieve` instead of `Profile.fetch`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Reactant_jll = "0192cb87-2b54-54ad-80e0-3be72ad8a3c0"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
 BenchmarkTools = "1.6.0"
@@ -27,3 +28,4 @@ PrecompileTools = "1.2.1"
 Printf = "1"
 Profile = "1"
 Reactant = "0.2.40"
+Serialization = "1"

--- a/src/data_free_ocean_climate_simulation.jl
+++ b/src/data_free_ocean_climate_simulation.jl
@@ -11,6 +11,7 @@ using CFTime
 using Dates
 using Printf
 using Profile
+using Serialization
 
 # https://github.com/CliMA/Oceananigans.jl/blob/da9959f3e5d8ee7cf2fb42b74ecc892874ec1687/src/AbstractOperations/conditional_operations.jl#L8
 Base.@nospecializeinfer function Reactant.traced_type_inner(
@@ -67,7 +68,7 @@ macro gbprofile(name::String, expr::Expr)
                 println(s, "# at ", $(string(__source__)))
                 $(Profile.print)(IOContext(s, :displaysize => (48, 1000)))
             end
-            write(string("profile_", $(esc(name)), ".dat"), $(Profile).fetch())
+            $(Serialization.serialize)(string("profile_", $(esc(name)), ".dat"), $(Profile).retrieve())
             $(Profile.clear)()
             out
         else


### PR DESCRIPTION
The former contains also the information about the stackframes and can be used for analysis in a different session with something like

```
Profile.print(deserialize("/path/to/profile_file.dat")...)
```

or similarly for other profile analysis tools.

NOTE: since this is using `Serialization.serialize` you must deserialize the data with the same version of Julia as the one used for serialization.

Follow up to #54, this should be more useful than that PR.  Still need testing with final dumps, but small local testing shows that this should work.