### PR TITLE
Run exe script from output directory

### DIFF
--- a/sharding/alps_scaling_test.jl
+++ b/sharding/alps_scaling_test.jl
@@ -53,4 +53,4 @@ srun --preserve-env --gpu-bind=per_task:1 --cpu_bind=verbose $(job_dir)/launcher
 """
 end
 
-generate_and_submit(alps_submit_job_writer, alps_config; input_file_name=@__FILE__)
+generate_and_submit(alps_submit_job_writer, alps_config; caller_file=@__FILE__)

--- a/sharding/common_submission_generator.jl
+++ b/sharding/common_submission_generator.jl
@@ -15,23 +15,23 @@ username = ENV["USER"]
     submit::Bool
 end
 
-function generate_and_submit(submit_job_writer, cfg::JobConfig; input_file_name::String)
+function generate_and_submit(submit_job_writer, cfg::JobConfig; caller_file::String)
 
     if !isone(length(Base.ARGS))
         error("""
               Usage:
 
-                  julia $(basename(input_file_name)) <SCRIPT_PATH>
+                  julia $(basename(caller_file)) <SCRIPT_PATH>
 
               E.g.:
 
-                  julia $(basename(input_file_name)) sharded_baroclinic_instability.jl
+                  julia $(basename(caller_file)) sharded_baroclinic_instability.jl
               """)
     end
 
     exe_path = Base.ARGS[1]
-    run_file = joinpath(@__DIR__, exe_path)
-    if !isfile(run_file)
+    input_file = joinpath(@__DIR__, exe_path)
+    if !isfile(input_file)
         error("File $(run_file) does not exist")
     end
     # Some filesystems don't like colons in directory names
@@ -53,8 +53,8 @@ function generate_and_submit(submit_job_writer, cfg::JobConfig; input_file_name:
         end
         cp(joinpath("..", filename), joinpath(out_path, filename))
     end
-    run_file_out = joinpath(out_path, basename(run_file))
-    cp(run_file, run_file_out)
+    run_file = joinpath(out_path, basename(input_file))
+    cp(input_file, run_file)
 
     @info "User: $(cfg.username); Project: $(cfg.account)"
     @info "run_file=$(run_file)"
@@ -106,7 +106,7 @@ echo "[\${SLURM_JOB_ID}.\${SLURM_PROCID}] Process exited with code \${?}"
             print(io, submit_job_writer(cfg::JobConfig, job_name::String,
                                         Nnodes::Int, job_dir::String, Ngpu::Int,
                                         resolution_fraction::Int,
-                                        project_path::String, run_file_out::String))
+                                        project_path::String, run_file::String))
         end
         if cfg.submit
             run(`sbatch $(sbatch_name)`)

--- a/sharding/common_submission_generator.jl
+++ b/sharding/common_submission_generator.jl
@@ -53,7 +53,8 @@ function generate_and_submit(submit_job_writer, cfg::JobConfig; input_file_name:
         end
         cp(joinpath("..", filename), joinpath(out_path, filename))
     end
-    cp(run_file, joinpath(out_path, basename(run_file)))
+    run_file_out = joinpath(out_path, basename(run_file))
+    cp(run_file, run_file_out)
 
     @info "User: $(cfg.username); Project: $(cfg.account)"
     @info "run_file=$(run_file)"
@@ -105,7 +106,7 @@ echo "[\${SLURM_JOB_ID}.\${SLURM_PROCID}] Process exited with code \${?}"
             print(io, submit_job_writer(cfg::JobConfig, job_name::String,
                                         Nnodes::Int, job_dir::String, Ngpu::Int,
                                         resolution_fraction::Int,
-                                        project_path::String, run_file::String))
+                                        project_path::String, run_file_out::String))
         end
         if cfg.submit
             run(`sbatch $(sbatch_name)`)

--- a/sharding/leonardo_scaling_test.jl
+++ b/sharding/leonardo_scaling_test.jl
@@ -53,4 +53,4 @@ srun --cpu-bind=verbose,cores $(job_dir)/launcher.sh $(Base.julia_cmd()[1]) --pr
 """
 end
 
-generate_and_submit(leonardo_submit_job_writer, leonardo_config; input_file_name=@__FILE__)
+generate_and_submit(leonardo_submit_job_writer, leonardo_config; caller_file=@__FILE__)

--- a/sharding/perlmutter_scaling_test.jl
+++ b/sharding/perlmutter_scaling_test.jl
@@ -47,4 +47,4 @@ srun -n $(Nnodes) -c 32 -G $(Ngpu) --cpu-bind=verbose,cores $(job_dir)/launcher.
 """
 end
 
-generate_and_submit(perlmutter_submit_job_writer, perlmutter_config; input_file_name=@__FILE__)
+generate_and_submit(perlmutter_submit_job_writer, perlmutter_config; caller_file=@__FILE__)


### PR DESCRIPTION
This allows us to run different copies of the same script in parallel. NOTE: this means the scripts can't have dependencies on relative paths, which would be broken when copying the file to a different place.

@glwagner @simone-silvestri this would break https://github.com/PRONTOLab/GB-25/blob/7dcfafc3d74dbd21d6877224774927b5bf21a645/sharding/sharded_baroclinic_instability.jl#L77 and https://github.com/PRONTOLab/GB-25/blob/7dcfafc3d74dbd21d6877224774927b5bf21a645/sharding/sharded_tripolar_instability.jl#L11
so I'm not pushing it and will wait for your comments, but I think it'd be very valuable to eventually move all relevant code to the package which can be loaded from any place so that these scripts are standalone and don't have dependencies on other local files.