### PR TITLE
Use closure=nothing by default in baroclinic instability model

### DIFF
--- a/src/baroclinic_instability_model.jl
+++ b/src/baroclinic_instability_model.jl
@@ -21,8 +21,9 @@ function baroclinic_instability_model(arch; resolution, Δt, Nz,
 
     # CATKE correctness is not established yet, so we are using a simpler closure
     # closure = Oceananigans.TurbulenceClosures.CATKEVerticalDiffusivity()
-    closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), κ=1e-5, ν=1e-4),
-
+    # closure = VerticalScalarDiffusivity(VerticallyImplicitTimeDiscretization(), κ=1e-5, ν=1e-4),
+    closure = nothing,
+        
     # Coriolis forces for a rotating Earth
     coriolis = HydrostaticSphericalCoriolis(),
 


### PR DESCRIPTION
While we debug Float32 for this closure. This probably has minimal impact on performance (up or down).