### PR TITLE
Stop testing Julia 1.10, PJRT runtime, use -O0 for compile tests

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -41,13 +41,11 @@ jobs:
           - 'baroclinic_instability'
           - 'ocean_climate'
         julia_version:
-          - '1.10'
           - '1.11'
         os:
           - ubuntu-24.04
           # - ubuntu-22.04-arm
         xla_runtime:
-          - 'PJRT'
           - 'IFRT'
     uses: ./.github/workflows/CompileOrRun.yml
     with:

--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -55,4 +55,4 @@ jobs:
       xla_runtime: ${{ matrix.xla_runtime }}
       compile_or_run: 'compile'
       earlyoom_threshold: 4
-      julia_optlevel: 2
+      julia_optlevel: 0


### PR DESCRIPTION
To alleviate CI costs because we would like to add more tests. @avik-pal @giordano 