### PR TITLE
A model with only tracers on a doubly-Periodic grid

### DIFF
--- a/.github/workflows/Run.yml
+++ b/.github/workflows/Run.yml
@@ -52,7 +52,7 @@ jobs:
             julia_version: '1.11'
             xla_runtime: 'IFRT'
             earlyoom_threshold: 4
- sim_type: 'ocean_climate'
+            sim_type: 'ocean_climate'
         # include:
         #   - os: mg
         #     julia_version: '1.11'

--- a/.github/workflows/Run.yml
+++ b/.github/workflows/Run.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sim_type: ['baroclinic_instability', 'ocean_climate']
+        sim_type: ['baroclinic_instability', 'ocean_climate', 'tracer_only']
         julia_version: ['1.11']
         os: ['ubuntu-24.04']
         xla_runtime: ['IFRT', 'PJRT']
@@ -52,7 +52,7 @@ jobs:
             julia_version: '1.11'
             xla_runtime: 'IFRT'
             earlyoom_threshold: 4
-            sim_type: 'ocean_climate'
+ sim_type: 'ocean_climate'
         # include:
         #   - os: mg
         #     julia_version: '1.11'

--- a/Project.toml
+++ b/Project.toml
@@ -22,19 +22,19 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [extensions]
-PrecompileTupledFillHaloRegionsF32 = ["Oceananigans", "Reactant"]
-PrecompileFillHaloRegionsF32 = ["Oceananigans", "Reactant"]
-
-# Split this into 3
-# PrecompileComputeTendenciesF32 = ["Oceananigans", "Reactant"]
-PrecompileComputeBoundaryTendenciesF32 = ["Oceananigans", "Reactant"]
-PrecompileComputeInteriorMomentumTendenciesF32 = ["Oceananigans", "Reactant"]
-PrecompileComputeInteriorTracerTendenciesF32 = ["Oceananigans", "Reactant"]
-
-PrecompileComputeAuxiliariesF32 = ["Oceananigans", "Reactant"]
-PrecompileAB2StepF32 = ["Oceananigans", "Reactant"]
-PrecompileCachePreviousTendenciesF32 = ["Oceananigans", "Reactant"]
-PrecompileInitializeF32 = ["Oceananigans", "Reactant"]
+# PrecompileTupledFillHaloRegionsF32 = ["Oceananigans", "Reactant"]
+# PrecompileFillHaloRegionsF32 = ["Oceananigans", "Reactant"]
+# 
+# # Split this into 3
+# # PrecompileComputeTendenciesF32 = ["Oceananigans", "Reactant"]
+# PrecompileComputeBoundaryTendenciesF32 = ["Oceananigans", "Reactant"]
+# PrecompileComputeInteriorMomentumTendenciesF32 = ["Oceananigans", "Reactant"]
+# PrecompileComputeInteriorTracerTendenciesF32 = ["Oceananigans", "Reactant"]
+# 
+# PrecompileComputeAuxiliariesF32 = ["Oceananigans", "Reactant"]
+# PrecompileAB2StepF32 = ["Oceananigans", "Reactant"]
+# PrecompileCachePreviousTendenciesF32 = ["Oceananigans", "Reactant"]
+# PrecompileInitializeF32 = ["Oceananigans", "Reactant"]
 
 # ClimaOcean-specific precompiler extensions
 # PrecompileDataFree = ["Oceananigans", "Reactant"]

--- a/simulations/tracer_only_simulation_run.jl
+++ b/simulations/tracer_only_simulation_run.jl
@@ -10,7 +10,7 @@ using Reactant
 preamble()
 
 Nt = ConcreteRNumber(3)
-Oceananigans.defaults.FloatType = Float32
+Oceananigans.defaults.FloatType = Float64
 
 @info "Generating model..."
 arch = ReactantState()
@@ -21,7 +21,7 @@ GC.gc(true); GC.gc(false); GC.gc(true)
 @info "Compiling..."
 rfirst! = @compile raise=true sync=true first_time_step!(model)
 rstep! = @compile raise=true sync=true time_step!(model)
-rloop! = @compile raise=true sync=true loop!(model, Ninner)
+rloop! = @compile raise=true sync=true loop!(model, Nt)
 
 @info "Running..."
 Reactant.with_profiler("./") do
@@ -31,6 +31,6 @@ Reactant.with_profiler("./") do
     rstep!(model)
 end
 Reactant.with_profiler("./") do
-    rloop!(model, Ninner)
+    rloop!(model, Nt)
 end
 @info "Done!"

--- a/simulations/tracer_only_simulation_run.jl
+++ b/simulations/tracer_only_simulation_run.jl
@@ -1,0 +1,46 @@
+using GordonBell25
+using GordonBell25: first_time_step!, time_step!, loop!, preamble
+using Oceananigans
+using Oceananigans.Architectures: ReactantState
+using Reactant
+
+# Reactant.Compiler.SROA_ATTRIBUTOR[] = false
+# Reactant.MLIR.IR.DUMP_MLIR_ALWAYS[] = true
+
+preamble()
+
+Nt = ConcreteRNumber(3)
+Oceananigans.defaults.FloatType = Float32
+
+@info "Generating model..."
+arch = ReactantState()
+model = GordonBell25.tracer_only_model(arch, Nx=32, Ny=32, Nz=32, Δt=1e-2)
+
+GC.gc(true); GC.gc(false); GC.gc(true)
+
+#=
+@time first_time_step!(model)
+@time time_step!(model)
+@time time_step!(model)
+@time time_step!(model)
+@time loop!(model, 10)
+@time loop!(model, 10)
+@time loop!(model, 10)
+=#
+
+@info "Compiling..."
+rfirst! = @compile raise=true sync=true first_time_step!(model)
+rstep! = @compile raise=true sync=true time_step!(model)
+rloop! = @compile raise=true sync=true loop!(model, Ninner)
+
+@info "Running..."
+Reactant.with_profiler("./") do
+    rfirst!(model)
+end
+Reactant.with_profiler("./") do
+    rstep!(model)
+end
+Reactant.with_profiler("./") do
+    rloop!(model, Ninner)
+end
+@info "Done!"

--- a/simulations/tracer_only_simulation_run.jl
+++ b/simulations/tracer_only_simulation_run.jl
@@ -13,24 +13,34 @@ Nt = ConcreteRNumber(3)
 Oceananigans.defaults.FloatType = Float64
 
 @info "Generating model..."
-arch = ReactantState()
-model = GordonBell25.tracer_only_model(arch, Nx=32, Ny=32, Nz=32, Δt=1e-2)
+arch = CPU()
+#arch = ReactantState()
+#arch = Distributed(ReactantState(), partition=Partition(2, 2, 1))
+halo = (0, 0, 0)
+model = GordonBell25.tracer_only_model(arch, halo, Nx=32, Ny=32, Nz=32, Δt=1e-2)
 
 GC.gc(true); GC.gc(false); GC.gc(true)
 
-@info "Compiling..."
-rfirst! = @compile raise=true sync=true first_time_step!(model)
-rstep! = @compile raise=true sync=true time_step!(model)
-rloop! = @compile raise=true sync=true loop!(model, Nt)
+if arch isa CPU
+    first_time_step!(model)
+    time_step!(model)
+    loop!(model, 3)
+else
+    @info "Compiling..."
+    rfirst! = @compile raise=true sync=true first_time_step!(model)
+    rstep! = @compile raise=true sync=true time_step!(model)
+    rloop! = @compile raise=true sync=true loop!(model, Nt)
 
-@info "Running..."
-Reactant.with_profiler("./") do
-    rfirst!(model)
+    @info "Running..."
+    Reactant.with_profiler("./") do
+        rfirst!(model)
+    end
+    Reactant.with_profiler("./") do
+        rstep!(model)
+    end
+    Reactant.with_profiler("./") do
+        rloop!(model, Nt)
+    end
 end
-Reactant.with_profiler("./") do
-    rstep!(model)
-end
-Reactant.with_profiler("./") do
-    rloop!(model, Nt)
-end
+
 @info "Done!"

--- a/simulations/tracer_only_simulation_run.jl
+++ b/simulations/tracer_only_simulation_run.jl
@@ -17,7 +17,7 @@ arch = CPU()
 #arch = ReactantState()
 #arch = Distributed(ReactantState(), partition=Partition(2, 2, 1))
 halo = (0, 0, 0)
-model = GordonBell25.tracer_only_model(arch, halo, Nx=32, Ny=32, Nz=32, Δt=1e-2)
+model = GordonBell25.tracer_only_model(arch; halo, Nx=32, Ny=32, Nz=32, Δt=1e-2)
 
 GC.gc(true); GC.gc(false); GC.gc(true)
 

--- a/simulations/tracer_only_simulation_run.jl
+++ b/simulations/tracer_only_simulation_run.jl
@@ -18,16 +18,6 @@ model = GordonBell25.tracer_only_model(arch, Nx=32, Ny=32, Nz=32, Δt=1e-2)
 
 GC.gc(true); GC.gc(false); GC.gc(true)
 
-#=
-@time first_time_step!(model)
-@time time_step!(model)
-@time time_step!(model)
-@time time_step!(model)
-@time loop!(model, 10)
-@time loop!(model, 10)
-@time loop!(model, 10)
-=#
-
 @info "Compiling..."
 rfirst! = @compile raise=true sync=true first_time_step!(model)
 rstep! = @compile raise=true sync=true time_step!(model)

--- a/src/GordonBell25.jl
+++ b/src/GordonBell25.jl
@@ -9,6 +9,5 @@ include("baroclinic_instability_model.jl")
 include("tracer_only_model.jl")
 include("sharding_utils.jl")
 include("precompile.jl")
-include("correctness.jl")
 
 end # module

--- a/src/GordonBell25.jl
+++ b/src/GordonBell25.jl
@@ -6,7 +6,9 @@ include("model_utils.jl")
 include("timestepping_utils.jl")
 include("data_free_ocean_climate_model.jl")
 include("baroclinic_instability_model.jl")
+include("tracer_only_model.jl")
 include("sharding_utils.jl")
 include("precompile.jl")
+include("correctness.jl")
 
 end # module

--- a/src/tracer_only_model.jl
+++ b/src/tracer_only_model.jl
@@ -1,0 +1,20 @@
+cᵢ(x, y, z) = exp(-(x^2 + y^2) / 128)
+
+function tracer_only_model(arch; Nx, Ny, Nz, Δt,
+    tracer_advection=Centered(order=2))
+
+    grid = RectilinearGrid(arch, size=(Nx, Ny, Nz), halo=(7, 7, 7),
+                           x=(-Nx/2, Nx/2), y=(-Ny/2, Ny/2), z=(0, Nz),
+                           topology = (Periodic, Periodic, Bounded))
+
+    model = HydrostaticFreeSurfaceModel(;
+        grid, velocities=PrescribedVelocityFields(),
+        tracers=:c, tracer_advection,
+    )
+
+    Random.seed!(42)
+    set!(model, c=cᵢ)
+    model.clock.last_Δt = Δt
+
+    return model
+end

--- a/src/tracer_only_model.jl
+++ b/src/tracer_only_model.jl
@@ -5,11 +5,10 @@ cᵢ(x, y, z) = exp(-(x^2 + y^2) / 128)
     return c - c^3 + log(abs(c) + 1)
 end
 
-function tracer_only_model(arch; Nx, Ny, Nz, Δt)
+function tracer_only_model(arch; Nx, Ny, Nz, Δt, halo=(0, 0, 0))
 
-    grid = LatitudeLongitudeGrid(arch,
+    grid = LatitudeLongitudeGrid(arch; halo,
         size = (Nx, Ny, Nz),
-        halo = (1, 1, 1),
         z = (0, 1),
         latitude = (-80, 80),
         longitude = (0, 360)


### PR DESCRIPTION
All arrays on grids that are doubly-Periodic in the horizontal directions have the same size. Also by eliminating the velocity fields with `velocities = PrescribedVelocityFields()` I believe that _all_ fields are `CenterField` but this should be checked.