### PR TITLE
Set IFRT runtime in Project.toml file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,3 +52,6 @@ Profile = "1"
 Reactant = "0.2.58"
 Serialization = "1"
 Setfield = "1.1.2"
+
+[preferences.Reactant]
+xla_runtime = "IFRT"


### PR DESCRIPTION
We want to always enforce this option, so better put it in the project file rather than asking folks to write the local preferences file just for this.