### PR TITLE
Make precompile of extensions run on GPU rather than devices

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -8,6 +8,7 @@ on:
       - 'simulations/baroclinic_instability_simulation_compile.jl'
       - 'simulations/ocean_climate_simulation_compile.jl'
       - 'Project.toml'
+      - 'ext/**'
       - 'src/**'
   push:
     branches:
@@ -20,6 +21,7 @@ on:
       - 'simulations/baroclinic_instability_simulation_compile.jl'
       - 'simulations/ocean_climate_simulation_compile.jl'
       - 'Project.toml'
+      - 'ext/**'
       - 'src/**'
   workflow_dispatch:
   schedule:

--- a/.github/workflows/Run.yml
+++ b/.github/workflows/Run.yml
@@ -8,6 +8,7 @@ on:
       - 'simulations/baroclinic_instability_simulation_run.jl'
       - 'simulations/ocean_climate_simulation_run.jl'
       - 'Project.toml'
+      - 'ext/**'
       - 'src/**'
   push:
     branches:
@@ -20,6 +21,7 @@ on:
       - 'simulations/baroclinic_instability_simulation_run.jl'
       - 'simulations/ocean_climate_simulation_run.jl'
       - 'Project.toml'
+      - 'ext/**'
       - 'src/**'
   workflow_dispatch:
   schedule:

--- a/ext/PrecompileAB2StepF32.jl
+++ b/ext/PrecompileAB2StepF32.jl
@@ -37,11 +37,22 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         Δt = FT(60)
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.ab2_step_workload!(model, Δt)
+        Reactant.compile(GordonBell25.ab2_step_workload!, (model, Δt); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileCachePreviousTendenciesF32.jl
+++ b/ext/PrecompileCachePreviousTendenciesF32.jl
@@ -37,11 +37,22 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
         Δt = ConcreteRNumber(60.0)
-        compiled! = @compile GordonBell25.correct_velocities_and_cache_previous_tendencies_workload!(model, Δt)
+        Reactant.compile(GordonBell25.correct_velocities_and_cache_previous_tendencies_workload!, (model, Δt); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileComputeAuxiliariesF32.jl
+++ b/ext/PrecompileComputeAuxiliariesF32.jl
@@ -37,10 +37,21 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.compute_auxiliaries_workload!(model)
+        Reactant.compile(GordonBell25.compute_auxiliaries_workload!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileComputeBoundaryTendenciesF32.jl
+++ b/ext/PrecompileComputeBoundaryTendenciesF32.jl
@@ -37,10 +37,22 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.compute_boundary_tendencies_workload!(model)
+        Reactant.compile(GordonBell25.compute_boundary_tendencies_workload!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileComputeInteriorMomentumTendenciesF32.jl
+++ b/ext/PrecompileComputeInteriorMomentumTendenciesF32.jl
@@ -37,10 +37,22 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.compute_interior_momentum_tendencies_workload!(model)
+        Reactant.compile(GordonBell25.compute_interior_momentum_tendencies_workload!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileComputeTendenciesF32.jl
+++ b/ext/PrecompileComputeTendenciesF32.jl
@@ -37,10 +37,21 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.compute_tendencies_workload!(model)
+        Reactant.compile(GordonBell25.compute_tendencies_workload!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileFillHaloRegionsF32.jl
+++ b/ext/PrecompileFillHaloRegionsF32.jl
@@ -37,10 +37,21 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.fill_halo_regions_workload!(model)
+        Reactant.compile(GordonBell25.fill_halo_regions_workload!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileInitializeF32.jl
+++ b/ext/PrecompileInitializeF32.jl
@@ -11,10 +11,21 @@ using PrecompileTools: @setup_workload, @compile_workload
     Nx, Ny, Nz = 64, 32, 4
     arch = Oceananigans.Architectures.ReactantState()
 
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
+
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile Oceananigans.initialize!(model)
+        Reactant.compile(Oceananigans.initialize!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64

--- a/ext/PrecompileTupledFillHaloRegionsF32.jl
+++ b/ext/PrecompileTupledFillHaloRegionsF32.jl
@@ -35,12 +35,23 @@ using Oceananigans.Models.HydrostaticFreeSurfaceModels:
     FT = Float32
     Oceananigans.defaults.FloatType = FT
     Nx, Ny, Nz = 64, 32, 4
+
+    if Reactant.XLA.REACTANT_XLA_RUNTIME == "PJRT"
+        client = Reactant.XLA.PJRT.CPUClient(; checkcount=false)
+    elseif Reactant.XLA.REACTANT_XLA_RUNTIME == "IFRT"
+        client = Reactant.XLA.IFRT.CPUClient(; checkcount=false)
+    else
+        error("Unsupported runtime: $(Reactant.XLA.REACTANT_XLA_RUNTIME)")
+    end
     arch = Oceananigans.Architectures.ReactantState()
 
     @compile_workload begin
         model = GordonBell25.baroclinic_instability_model(arch; resolution=4, Δt=60, Nz=4, grid_type=:simple_lat_lon)
-        compiled! = @compile GordonBell25.tupled_fill_halo_regions_workload!(model)
+        Reactant.compile(GordonBell25.tupled_fill_halo_regions_workload!, (model,); client, optimize=:all)
     end
+
+    XLA.free_client(client)
+    client.client = C_NULL
 
     # Reset float type
     Oceananigans.defaults.FloatType = Float64


### PR DESCRIPTION
@wsmoses is this OK?  On the login nodes on Alps the GPUs are present but not accessible, making it impossible to precompile anything there and forcing using the compute nodes unnecessarily.  Also, they won't be available all the time, so reducing the need to use compute nodes would be very important.