### PR TITLE
Use `--compiled-modules=strict` to launch Julia

### DIFF
--- a/sharding/alps_scaling_test.jl
+++ b/sharding/alps_scaling_test.jl
@@ -4,14 +4,14 @@ out_dir = @__DIR__
 
 # run params
 account  = "g191"
-submit   = false
+submit   = true
 run_name = "reactant_"
-time     = "00:40:00"
+time     = "00:30:00"
 Ngpus    = [4, 8] #[4, 8, 12, 16]
 type     = "weak"
 
 gpus_per_node = 4
-cpus_per_task = 16
+cpus_per_task = 288
 
 alps_config = JobConfig(; username, account, out_dir, time, cpus_per_task, Ngpus,
                         run_name, gpus_per_node, type, submit)
@@ -35,6 +35,7 @@ function alps_submit_job_writer(cfg::JobConfig, job_name, Nnodes, job_dir, Ngpu,
 #SBATCH --exclusive
 
 export MPICH_GPU_SUPPORT_ENABLED=0
+export JULIA_CUDA_USE_COMPAT=false
 export FI_MR_CACHE_MONITOR=disabled
 
 ulimit -s unlimited
@@ -44,7 +45,7 @@ ulimit -s unlimited
 # We only set it to `verbose` to record what's going on.
 srun --uenv=prgenv-gnu --preserve-env --cpu_bind=verbose \
     --export=ALL,LD_PRELOAD="/user-environment/linux-sles15-neoverse_v2/gcc-13.3.0/nccl-2.22.3-1-4j6h3ffzysukqpqbvriorrzk2lm762dd/lib/libnccl.so.2" \
-    $(job_dir)/launcher.sh $(Base.julia_cmd()[1]) --project=$(project_path) --startup-file=no --threads=$(cfg.cpus_per_task) -O0 $(run_file)
+    $(job_dir)/launcher.sh $(Base.julia_cmd()[1]) --project=$(project_path) --startup-file=no --threads=16 --compiled-modules=strict -O0 $(run_file)
 """
 end
 

--- a/sharding/leonardo_scaling_test.jl
+++ b/sharding/leonardo_scaling_test.jl
@@ -45,7 +45,7 @@ export JULIA_CUDA_MEMORY_POOL=none
 module load cuda/12.3
 srun --cpu-bind=verbose,cores \
      --export=ALL,LD_PRELOAD="/leonardo/prod/spack/5.2/install/0.21/linux-rhel8-icelake/gcc-12.2.0/nccl-2.19.3-1-cuoct3jempfrtirmnjwtxwr2wwgqrrbv/lib/libnccl.so.2" \
-     $(job_dir)/launcher.sh $(Base.julia_cmd()[1]) --project=$(project_path) --startup-file=no --pkgimages=existing -O0 $(run_file)
+     $(job_dir)/launcher.sh $(Base.julia_cmd()[1]) --project=$(project_path) --startup-file=no --compiled-modules=strict -O0 $(run_file)
 """
 end
 

--- a/sharding/perlmutter_scaling_test.jl
+++ b/sharding/perlmutter_scaling_test.jl
@@ -59,7 +59,7 @@ export NCCL_BUFFSIZE=33554432
 export JULIA_CUDA_USE_COMPAT=false
 
 
-srun -n $(Nnodes) -c 32 -G $(Ngpu) --cpu-bind=verbose,cores $(job_dir)/launcher.sh julia --project=$(project_path) -O0 $(run_file) 
+srun -n $(Nnodes) -c 32 -G $(Ngpu) --cpu-bind=verbose,cores $(job_dir)/launcher.sh julia --project=$(project_path) --compiled-modules=strict -O0 $(run_file) 
 """
 end
 


### PR DESCRIPTION
We want to fail as early as possible in case the environment isn't fully precompiled, to avoid a storm of thousands of processes all trying to precompile the world (at least we have locks now to avoid total chaos).