### PR TITLE
Also save XLA code

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/Compile.yml'
       - '.github/workflows/CompileOrRun.yml'
+      - 'sharding/sharded_baroclinic_instability_simulation_compile.jl'
       - 'simulations/baroclinic_instability_simulation_compile.jl'
       - 'simulations/ocean_climate_simulation_compile.jl'
       - 'Project.toml'
@@ -17,6 +18,7 @@ on:
     paths:
       - '.github/workflows/Compile.yml'
       - '.github/workflows/CompileOrRun.yml'
+      - 'sharding/sharded_baroclinic_instability_simulation_compile.jl'
       - 'simulations/baroclinic_instability_simulation_compile.jl'
       - 'simulations/ocean_climate_simulation_compile.jl'
       - 'Project.toml'
@@ -56,6 +58,26 @@ jobs:
       julia_version: ${{ matrix.julia_version }}
       os: ${{ matrix.os }}
       xla_runtime: ${{ matrix.xla_runtime }}
+      compile_or_run: 'compile'
+      earlyoom_threshold: 4
+      julia_optlevel: 0
+
+  compile_sharded:
+    name: Sharded - Julia ${{ matrix.julia_version }} - ${{ matrix.grid_type }} - ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+          os: ['ubuntu-24.04']
+          grid_type: ['simple_lat_lon']
+    uses: ./.github/workflows/CompileOrRun.yml
+    with:
+      sim_type: 'sharded_baroclinic_instability'
+      grid_type: ${{ matrix.grid_type }}
+      sharded: true
+      run_dir: 'sharding'
+      julia_version: '1.11'
+      os: ${{ matrix.os }}
+      xla_runtime: 'IFRT'
       compile_or_run: 'compile'
       earlyoom_threshold: 4
       julia_optlevel: 0

--- a/sharding/sharded_baroclinic_instability_simulation_compile.jl
+++ b/sharding/sharded_baroclinic_instability_simulation_compile.jl
@@ -47,10 +47,10 @@ for optimize in (:before_raise, false, :before_jit), code_type in (:hlo, :xla)
         end
     elseif code_type === :xla
         first_code = try_compile_code() do
-            @code_xla optimize=optimize raise=true first_time_step!(model)
+            @code_xla raise=true first_time_step!(model)
         end
         loop_code = try_compile_code() do
-            @code_xla optimize=optimize raise=true loop!(model, Ninner)
+            @code_xla raise=true loop!(model, Ninner)
         end
     end
     for name in ("first", "loop"), debug in (true, false)

--- a/sharding/sharded_baroclinic_instability_simulation_compile.jl
+++ b/sharding/sharded_baroclinic_instability_simulation_compile.jl
@@ -1,0 +1,67 @@
+using GordonBell25: first_time_step!, loop!, try_compile_code, preamble, TRY_COMPILE_FAILED
+using GordonBell25: baroclinic_instability_model, PROFILE, GordonBell25
+using Reactant
+using Oceananigans
+using Oceananigans.Architectures: ReactantState
+
+PROFILE[] = true
+Oceananigans.defaults.FloatType = Float32
+
+preamble()
+
+GordonBell25.initialize(; single_gpu_per_process=false)
+@show Ndev = length(Reactant.devices())
+
+Rx, Ry = GordonBell25.factors(Ndev)
+if Ndev == 1
+    rank = 0
+    arch = Oceananigans.ReactantState()
+else
+    arch = Oceananigans.Distributed(
+        Oceananigans.ReactantState();
+        partition = Partition(Rx, Ry, 1)
+    )
+    rank = Reactant.Distributed.local_rank()
+end
+
+@info "Generating model..."
+arch = ReactantState()
+model = baroclinic_instability_model(arch, resolution=8, Δt=60, Nz=10)
+
+GC.gc(true); GC.gc(false); GC.gc(true)
+
+TRY_COMPILE_FAILED[] = false
+Ninner = ConcreteRNumber(2)
+
+for optimize in (:before_raise, false, :before_jit), code_type in (:hlo, :xla)
+    # We only want the optimised XLA code
+    optimize in (:before_raise, false) && code_type === :xla && continue
+    kernel_type = optimize === :before_raise ? "before_raise" : (optimize === false ? "unoptimised" : "optimised")
+    @info "Compiling $(kernel_type) $(code_type) kernels..."
+    if code_type === :hlo
+        first_code = try_compile_code() do
+            @code_hlo optimize=optimize raise=true first_time_step!(model)
+        end
+        loop_code = try_compile_code() do
+            @code_hlo optimize=optimize raise=true loop!(model, Ninner)
+        end
+    elseif code_type === :xla
+        first_code = try_compile_code() do
+            @code_xla optimize=optimize raise=true first_time_step!(model)
+        end
+        loop_code = try_compile_code() do
+            @code_xla optimize=optimize raise=true loop!(model, Ninner)
+        end
+    end
+    for name in ("first", "loop"), debug in (true, false)
+        # No debug info for `@code_xla`
+        code_type === :xla && debug && continue
+        open("$(kernel_type)_baroclinic_instability_simulation_$(name)$(debug ? "_debug" : "")_$(code_type).mlir", "w") do io
+            show(IOContext(io, :debug => debug), (Base.@locals())[Symbol(name, "_code")])
+        end
+    end
+end
+
+if TRY_COMPILE_FAILED[]
+    error("compilation failed")
+end

--- a/simulations/baroclinic_instability_simulation_compile.jl
+++ b/simulations/baroclinic_instability_simulation_compile.jl
@@ -18,7 +18,7 @@ GC.gc(true); GC.gc(false); GC.gc(true)
 TRY_COMPILE_FAILED[] = false
 Ninner = ConcreteRNumber(2)
 
-for optimize in (:before_raise, false, :before_jit), code_type in (:hlo,)
+for optimize in (:before_raise, false, :before_jit), code_type in (:hlo, :xla)
     # We only want the optimised XLA code
     optimize in (:before_raise, false) && code_type === :xla && continue
     kernel_type = optimize === :before_raise ? "before_raise" : (optimize === false ? "unoptimised" : "optimised")

--- a/simulations/ocean_climate_simulation_compile.jl
+++ b/simulations/ocean_climate_simulation_compile.jl
@@ -16,7 +16,7 @@ GC.gc(true); GC.gc(false); GC.gc(true)
 TRY_COMPILE_FAILED[] = false
 Ninner = ConcreteRNumber(2)
 
-for optimize in (:before_raise, false, :before_jit), code_type in (:hlo,)
+for optimize in (:before_raise, false, :before_jit), code_type in (:hlo, :xla)
     # We only want the optimised XLA code
     optimize in (:before_raise, false) && code_type === :xla && continue
     kernel_type = optimize === :before_raise ? "before_raise" : (optimize === false ? "unoptimised" : "optimised")


### PR DESCRIPTION
@wsmoses I reorganised the "compile" jobs to also save the XLA code, but this doesn't contain any `%all-to-all` or `%all-gather`.  I think this is because these jobs don't do sharding?

We already have the XLA dump for the sharded "run" jobs, should we do the check for the presence of `%all-to-all` or `%all-gather` on those instead?