### PR TITLE
[CI] Put constraints on the number of collective operations

### DIFF
--- a/.github/workflows/CompileOrRun.yml
+++ b/.github/workflows/CompileOrRun.yml
@@ -139,10 +139,14 @@ jobs:
                   echo "----------"
                   echo "${COLLECTIVES}"
                   echo "----------"
-                  OK="false"
+                  if [[ "${OP}" == "all-to-all" && ${NUM_COLLECTIVES} -gt 4 ]] || [[ "${OP}" == "all-gather" && ${NUM_COLLECTIVES} -gt 0 ]] || [[ "${OP}" == "all-reduce" && ${NUM_COLLECTIVES} -gt 299 ]]; then
+                      OK="false"
+                  fi
               fi
           done
-          exit 0 # TODO: eventually change this to check the value of `${OK}`
+          if [[ "${OK}" == "false" ]]; then
+              exit 1
+          fi
       - name: Upload MLIR and XLA modules
         uses: actions/upload-artifact@v4
         timeout-minutes: 10


### PR DESCRIPTION
In [last run](https://github.com/PRONTOLab/GB-25/actions/runs/14439731228) we had 3 `all-to-all`s and 297 `all-reduce`s.  Compared to https://github.com/PRONTOLab/GB-25/pull/188#issuecomment-2800016025, `all-to-all`s are down from 12, and `all-gather`s completely disappeared, so this may be a good time to start putting some constraints.