### PR TITLE
Use Breeze glw/hevi-imex-docs split-explicit substepping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [sources]
-Breeze = {rev = "dkz/feat-reactant-version", url = "https://github.com/NumericalEarth/Breeze.jl.git"}
+Breeze = {rev = "glw/hevi-imex-docs", url = "https://github.com/NumericalEarth/Breeze.jl.git"}
 NumericalEarth = {rev = "glw/manual-iterate", url = "https://github.com/NumericalEarth/NumericalEarth.jl.git"}
 Oceananigans = {rev = "dkz/fix-ranges", url = "https://github.com/dkytezab/Oceananigans.jl.git"}
 Reactant = {rev = "main", url = "https://github.com/EnzymeAD/Reactant.jl.git"}
@@ -39,7 +39,7 @@ Reactant = {rev = "main", url = "https://github.com/EnzymeAD/Reactant.jl.git"}
 [compat]
 ArgParse = "1.2.0"
 BFloat16s = "0.6.1"
-Breeze = "= 0.4.5"
+Breeze = "0.4"
 CUDA = "5.7.1"
 CairoMakie = "0.15.9"
 ClimaSeaIce = "= 0.4.5"

--- a/src/moist_baroclinic_wave_model.jl
+++ b/src/moist_baroclinic_wave_model.jl
@@ -13,7 +13,7 @@
 
 using KernelAbstractions: @kernel, @index
 using Breeze
-using Breeze: AtmosphereModel, CompressibleDynamics, ExplicitTimeStepping
+using Breeze: AtmosphereModel, CompressibleDynamics, ExplicitTimeStepping, SplitExplicitTimeDiscretization
 using Breeze: BulkDrag, BulkSensibleHeatFlux, BulkVaporFlux
 using Breeze.AtmosphereModels: dynamics_density, specific_prognostic_moisture
 using Breeze.Microphysics: NonEquilibriumCloudFormation
@@ -297,27 +297,36 @@ end
 # ═══════════════════════════════════════════════════════════════════════════
 
 """
-    moist_baroclinic_wave_model(arch; Nλ=360, Nφ=170, Nz=30, H=30e3, Δt=2.0, halo=(5,5,5))
+    moist_baroclinic_wave_model(arch; Nλ=360, Nφ=170, Nz=30, H=30e3, Δt=nothing, halo=(5,5,5))
 
 Build a Breeze `AtmosphereModel` on a global LatitudeLongitudeGrid initialised
 with the DCMIP-2016 moist baroclinic wave (Test 1-1).
 
 Components
-  • `CompressibleDynamics` with reference θ from the equatorial profile
+  • `CompressibleDynamics` with `SplitExplicitTimeDiscretization` (WS-RK3 +
+    acoustic substepping) — enables advective-CFL outer time steps
   • `HydrostaticSphericalCoriolis`
   • `WENO(order=5)` advection (flux form)
   • `OneMomentCloudMicrophysics` (mixed-phase non-equilibrium with ice)
 
 Grid: 0°–360° longitude, ±85° latitude, 0–`H` m altitude.
 Default resolution ≈ 1° (Nλ=360, Nφ=170).
+
+Time step: `Δt = 60 s` is stable at 1° (Nλ=360) with split-explicit
+substepping. If `Δt === nothing`, it is scaled linearly with horizontal
+resolution as `Δt = 60 · (360 / Nλ)` s so doubling the resolution halves Δt.
 """
 function moist_baroclinic_wave_model(arch;
                                      Nλ   = 360,
                                      Nφ   = 170,
                                      Nz   = 30,
                                      H    = 30e3,
-                                     Δt   = 2.0,
+                                     Δt   = nothing,
                                      halo = (5, 5, 5))
+
+    # Advective-CFL Δt for split-explicit substepping: 60 s at 1° (Nλ=360),
+    # scaling linearly with horizontal grid spacing.
+    Δt_value = isnothing(Δt) ? 60.0 * (360 / Nλ) : Δt
 
     grid = LatitudeLongitudeGrid(arch;
                                  size = (Nλ, Nφ, Nz),
@@ -328,7 +337,7 @@ function moist_baroclinic_wave_model(arch;
 
     coriolis = SphericalCoriolis()
 
-    dynamics = CompressibleDynamics(ExplicitTimeStepping();
+    dynamics = CompressibleDynamics(SplitExplicitTimeDiscretization();
                                    surface_pressure = p_ref,
                                    reference_potential_temperature = theta_reference)
 
@@ -353,7 +362,7 @@ function moist_baroclinic_wave_model(arch;
     model = AtmosphereModel(grid; dynamics, coriolis, advection, microphysics, boundary_conditions)
 
     FT = eltype(grid)
-    model.clock.last_Δt = FT(Δt)
+    model.clock.last_Δt = FT(Δt_value)
 
     set_moist_baroclinic_wave!(model)
 


### PR DESCRIPTION
## Summary

Switches the moist baroclinic wave setup to Breeze's split-explicit
(WS-RK3 + acoustic substepping) time discretization from the
[`glw/hevi-imex-docs`](https://github.com/NumericalEarth/Breeze.jl/tree/glw/hevi-imex-docs)
branch. This lets the outer step run at the advective CFL instead of the
acoustic CFL — roughly a 6× larger Δt for the same grid.

Changes:
- `Project.toml`: point `Breeze` source at `glw/hevi-imex-docs`; relax `Breeze` compat to `"0.4"`.
- `src/moist_baroclinic_wave_model.jl`:
  - Import `SplitExplicitTimeDiscretization` from Breeze.
  - `CompressibleDynamics` now uses `SplitExplicitTimeDiscretization()` (defaults: `ProportionalSubsteps`, auto substep count from acoustic CFL).
  - `Δt` kwarg now defaults to `nothing`. When unset it is computed as `Δt = 60 · (360 / Nλ)` s, so `Δt = 60 s` at 1° (`Nλ = 360`) and halves each time the horizontal resolution doubles. An explicit `Δt` kwarg still overrides.

## Dependency resolution

The `glw/hevi-imex-docs` branch of Breeze was previously pinned at 0.4.1,
which conflicted with `NumericalEarth@glw/manual-iterate` (requires
Breeze ≥ 0.4.4). That has been fixed upstream:

- NumericalEarth/Breeze.jl@`glw/hevi-imex-docs` → `Bump version to 0.4.5` (05c4910)

`Pkg.instantiate()` now resolves cleanly against this PR.

## Test plan
- [x] `Pkg.instantiate()` resolves
- [ ] `julia --project=. simulations/atmosphere_simulation_run.jl` — single-GPU compile + run
- [ ] `julia --project=. sharding/sharded_atmosphere_simulation_run.jl` — sharded run on 8 GPUs
- [ ] Confirm stability at `Δt = 60 s` for 1° (Nλ=360) and at the scaled Δt for higher resolutions