### PR TITLE
Snapshot and precompile entire GB-25 repo at out_path (not just .toml files)

### DIFF
--- a/sharding/common_submission_generator.jl
+++ b/sharding/common_submission_generator.jl
@@ -3,10 +3,17 @@ using Dates, Random
 username = ENV["USER"]
 
 function snapshot_project!(snapshot_path::AbstractString, project_path::AbstractString)
-    cp(project_path, snapshot_path; force=true)
+    mkpath(snapshot_path)
 
-    # The benchmark snapshot should be self-contained, but it does not need git metadata.
-    rm(joinpath(snapshot_path, ".git"); recursive=true, force=true)
+    tracked_files = split(readchomp(`git -C $(project_path) ls-files`), '\n')
+    for relpath in tracked_files
+        isempty(relpath) && continue
+        src = joinpath(project_path, relpath)
+        dst = joinpath(snapshot_path, relpath)
+        mkpath(dirname(dst))
+        cp(src, dst; force=true)
+    end
+
     return snapshot_path
 end
 

--- a/sharding/common_submission_generator.jl
+++ b/sharding/common_submission_generator.jl
@@ -10,6 +10,12 @@ function snapshot_project!(snapshot_path::AbstractString, project_path::Abstract
     return snapshot_path
 end
 
+function precompile_snapshot!(snapshot_project_path::AbstractString)
+    @info "Precompiling snapshot project on the login node" snapshot_project_path
+    run(`$(Base.julia_cmd()[1]) --project=$(snapshot_project_path) --compiled-modules=yes -O0 -e 'using Pkg; Pkg.precompile(); using GordonBell25'`)
+    return nothing
+end
+
 run_prefix = get(ENV, "GB25_RUN_PREFIX", "runs")
 run_postfix = get(ENV, "GB25_RUN_POSTFIX", randstring(4))
 
@@ -71,8 +77,11 @@ function generate_and_submit(submit_job_writer, cfg::JobConfig; caller_file::Str
 
     # Snapshot the entire repository so submitted jobs do not depend on later edits
     # to the live checkout.
+    # Note: Also need to precompile there since Julia pkgimages are tied to the
+    # source tree location they were built from. 
     snapshot_project_path = joinpath(out_path, basename(project_path))
     snapshot_project!(snapshot_project_path, project_path)
+    precompile_snapshot!(snapshot_project_path)
 
     # Run the snapshotted copy of the selected script.
     run_file = joinpath(snapshot_project_path, relpath(input_file, project_path))

--- a/sharding/common_submission_generator.jl
+++ b/sharding/common_submission_generator.jl
@@ -2,6 +2,14 @@ using Dates, Random
 
 username = ENV["USER"]
 
+function snapshot_project!(snapshot_path::AbstractString, project_path::AbstractString)
+    cp(project_path, snapshot_path; force=true)
+
+    # The benchmark snapshot should be self-contained, but it does not need git metadata.
+    rm(joinpath(snapshot_path, ".git"); recursive=true, force=true)
+    return snapshot_path
+end
+
 run_prefix = get(ENV, "GB25_RUN_PREFIX", "runs")
 run_postfix = get(ENV, "GB25_RUN_POSTFIX", randstring(4))
 
@@ -38,9 +46,9 @@ function generate_and_submit(submit_job_writer, cfg::JobConfig; caller_file::Str
         error("File $(input_file) does not exist")
     end
     # Some filesystems don't like colons in directory names
+    project_path = dirname(@__DIR__)
     timestamp = replace(string(now(UTC)), ':' => '-')
     out_path = joinpath(cfg.out_dir, run_prefix, "$(timestamp)_$(run_postfix)")
-    project_path = dirname(@__DIR__)
 
     manifest_file = let
         dir = readdir(project_path)
@@ -61,15 +69,13 @@ function generate_and_submit(submit_job_writer, cfg::JobConfig; caller_file::Str
 
     mkpath(out_path)
 
-    # Copy environment files and run files for future reference.
-    for filename in ("Project.toml", manifest_file, "LocalPreferences.toml")
-        if filename == "LocalPreferences.toml" && !isfile(joinpath("..", filename))
-            continue
-        end
-        cp(joinpath("..", filename), joinpath(out_path, filename))
-    end
-    run_file = joinpath(out_path, basename(input_file))
-    cp(input_file, run_file)
+    # Snapshot the entire repository so submitted jobs do not depend on later edits
+    # to the live checkout.
+    snapshot_project_path = joinpath(out_path, basename(project_path))
+    snapshot_project!(snapshot_project_path, project_path)
+
+    # Run the snapshotted copy of the selected script.
+    run_file = joinpath(snapshot_project_path, relpath(input_file, project_path))
 
     # Capture repository state
     git_describe = readchomp(`git -C $(project_path) --no-pager describe --tags --always --dirty`)
@@ -149,7 +155,7 @@ echo "[\${SLURM_JOB_ID}.\${SLURM_PROCID}] Process exited with code \${?}"
             print(io, submit_job_writer(cfg::JobConfig, job_name::String,
                                         Nnodes::Int, job_dir::String, Ngpu::Int,
                                         resolution_fraction::Int,
-                                        project_path::String, run_file::String))
+                                        snapshot_project_path::String, run_file::String))
         end
         if cfg.submit
             run(`sbatch $(sbatch_name)`)


### PR DESCRIPTION
My jobs keep dying with 
```
ERROR: LoadError: Precompiled image Base.PkgId(Base.UUID("01bae11a-8c86-47ea-956a-4644a8dd5e5e"), "GordonBell25") not available with flags CacheFlags(; use_pkgimages=true, debug_level=1, check_bounds=0, inline=true, opt_level=0)
```
because I unwittingly changed something in the GordonBell25 module at the `project_path` (requiring a re-precompile) in between the time I submitted the job and the time the job launched.

This PR proposes a solution to this problem by, instead of just copying the Manifest.toml and Project.toml to the `out_path`, copy the whole `GB-25/` repo to `out_path/`, precompile it there, and then refer to that snapshot in `submit.sh` instead of referring to the original `project_path`.

Good idea? Bad idea? Better way to get around this problem?