### PR TITLE
Add commented out comms opts off compile_options

### DIFF
--- a/sharding/sharded_baroclinic_instability_simulation_run.jl
+++ b/sharding/sharded_baroclinic_instability_simulation_run.jl
@@ -104,7 +104,13 @@ if devarch isa Oceananigans.ReactantState
 end
 
 @info "[$rank] Compiling first_time_step!..." now(UTC)
+
 compile_options = CompileOptions(; sync=true, raise=true, strip_llvm_debuginfo=true, strip=:all, multifloat=GordonBell25.multifloat_from_args(parsed_args))
+# uncomment to turn communication optimizations off
+# Note: may need to also increase xla timeout to get this to run, eg:
+# # export XLA_FLAGS="--xla_gpu_first_collective_call_warn_stuck_timeout_seconds=100 --xla_gpu_first_collective_call_terminate_timeout_seconds=300 \${XLA_FLAGS}"
+compile_options = CompileOptions(; sync=true, raise=true, strip_llvm_debuginfo=true, strip=:all, multifloat=GordonBell25.multifloat_from_args(parsed_args), xla_debug_options=(xla_enable_enzyme_comms_opt=false,), optimize_communications=false)
+
 rfirst! = if devarch isa Oceananigans.ReactantState
      @compile compile_options=compile_options first_time_step!(model)
 else


### PR DESCRIPTION
Checking this in to make sure we're all on the same page. 

@wsmoses @giordano please confirm these are the right flags to turn off comms optimizations

Also are 100, 300 reasonable timeout numbers? This was sufficient for single node. Haven't yet tested on larger.