### PR TITLE
Fix GCP bucket cache condition in reusable workflow

### DIFF
--- a/.github/workflows/CompileOrRun.yml
+++ b/.github/workflows/CompileOrRun.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ startsWith(inputs.os, 'ubuntu') }}
         with:
           cache-name: julia-cache;workflow=${{ inputs.julia_version }}-${{ inputs.sim_type }}-${{ inputs.os }}-${{ inputs.xla_runtime }}-${{ inputs.compile_or_run }};job=${{ github.job }}
-          gcp-bucket: ${{ contains(matrix.os, 'linux') && 'enzyme-ci-transient' || '' }}
+          gcp-bucket: ${{ startsWith(inputs.os, 'ubuntu') && 'enzyme-ci-transient' || '' }}
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2
         with:


### PR DESCRIPTION
## Summary
- `matrix` isn't in scope inside a `workflow_call` reusable workflow, so the `gcp-bucket` condition on the `julia-actions/cache` step at CompileOrRun.yml:67 never evaluated true, leaving the GCP cache bucket added in 6078511 unused.
- Switched to `startsWith(inputs.os, 'ubuntu')`, matching the pattern already used for the other Linux-only steps in this file (earlyoom install, setup-julia, cache step's own `if:`).

## Test plan
- [ ] Confirm the `julia-actions/cache` step logs show `gcp-bucket: enzyme-ci-transient` on ubuntu runners in the next workflow run